### PR TITLE
Bug/25 error handling in create timesheet

### DIFF
--- a/src/app/screens/TimesheetScreen/interface/index.ts
+++ b/src/app/screens/TimesheetScreen/interface/index.ts
@@ -12,3 +12,8 @@ export interface Timesheet {
   project?: string;
   project_id: string;
 }
+
+export interface ITimesheetSectionListItem {
+  title: string;
+  data: Timesheet[];
+}

--- a/src/app/screens/TimesheetScreen/timesheet.hooks.ts
+++ b/src/app/screens/TimesheetScreen/timesheet.hooks.ts
@@ -119,8 +119,7 @@ export const useAddTimesheet = () => {
   const {mutate, data, isLoading, isSuccess} = useMutation(
     (payload: TimesheetRequestBody) => createTimesheetRequest(payload),
     {
-      onSuccess: successData => {
-        toast(successData?.data?.message);
+      onSuccess: () => {
         queryClient.invalidateQueries(['timesheet']);
       },
       onError: (err: AxiosError) => {
@@ -130,14 +129,14 @@ export const useAddTimesheet = () => {
     },
   );
 
-  const isPartiallyFailed = isSuccess && Boolean(data?.data.data.length);
+  const isEmpty = !Object.keys(data?.data.data ?? {}).length;
 
   return {
     mutate,
     isLoading,
-    isSuccess: isSuccess && !data?.data.data.length,
-    isPartiallyFailed,
+    isSuccess: isSuccess && isEmpty,
+    isPartiallyFailed: isSuccess && !isEmpty,
     failedTimesheets: data?.data.data,
-    errorMessage: data?.data.message,
+    message: data?.data.message,
   };
 };

--- a/src/app/screens/TimesheetScreen/timesheet.hooks.ts
+++ b/src/app/screens/TimesheetScreen/timesheet.hooks.ts
@@ -116,11 +116,11 @@ export const useEditTimesheet = () => {
 export const useAddTimesheet = () => {
   const queryClient = useQueryClient();
 
-  const {mutate, isLoading, isSuccess} = useMutation(
+  const {mutate, data, isLoading, isSuccess} = useMutation(
     (payload: TimesheetRequestBody) => createTimesheetRequest(payload),
     {
-      onSuccess: data => {
-        toast(data?.data?.message);
+      onSuccess: successData => {
+        toast(successData?.data?.message);
         queryClient.invalidateQueries(['timesheet']);
       },
       onError: (err: AxiosError) => {
@@ -129,5 +129,15 @@ export const useAddTimesheet = () => {
       },
     },
   );
-  return {mutate, isLoading, isSuccess};
+
+  const isPartiallyFailed = isSuccess && Boolean(data?.data.data.length);
+
+  return {
+    mutate,
+    isLoading,
+    isSuccess: isSuccess && !data?.data.data.length,
+    isPartiallyFailed,
+    failedTimesheets: data?.data.data,
+    errorMessage: data?.data.message,
+  };
 };

--- a/src/app/screens/TimesheetScreen/view/createTimesheet.tsx
+++ b/src/app/screens/TimesheetScreen/view/createTimesheet.tsx
@@ -11,8 +11,9 @@ import Touchable from '../../../components/touchable';
 import {useAddTimesheet} from '../timesheet.hooks';
 
 import {convertToMins, dateFormate} from '../../../utils/date';
+import {convertFailedTimesheetsResponse} from '../../../utils/timesheet';
 
-import {Timesheet} from '../interface';
+import {ITimesheetSectionListItem, Timesheet} from '../interface';
 import colors from '../../../constant/colors';
 import fonts from '../../../constant/fonts';
 import strings from '../../../constant/strings';
@@ -26,14 +27,9 @@ type Props = {
   userName?: string;
 };
 
-type CreateTimesheetDataprop = {
-  title: string;
-  data: Timesheet[];
-};
-
 const CreateTimesheet = ({toggleModal, isVisible, userId, userName}: Props) => {
   const [addedTimesheet, setAddedTimesheet] = useState<
-    CreateTimesheetDataprop[]
+    ITimesheetSectionListItem[]
   >([]);
   const [formDefaultData, setFormDefaultData] = useState<Timesheet | undefined>(
     undefined,
@@ -41,11 +37,18 @@ const CreateTimesheet = ({toggleModal, isVisible, userId, userName}: Props) => {
   const [isFormVisible, setIsFormVisible] = useState<boolean>(true);
   const isKeyboardVisible = useIsKeyboardShown();
 
-  const {mutate, isSuccess, isLoading} = useAddTimesheet();
+  const {
+    mutate,
+    isSuccess,
+    isLoading,
+    isPartiallyFailed,
+    failedTimesheets,
+    errorMessage,
+  } = useAddTimesheet();
 
   // mutation function
   const mutationFunc = useCallback(
-    (data: CreateTimesheetDataprop[]) => {
+    (data: ITimesheetSectionListItem[]) => {
       const timesheetsData = data.flatMap(section =>
         section.data.map(value => ({
           project_id: value.project_id,
@@ -72,11 +75,11 @@ const CreateTimesheet = ({toggleModal, isVisible, userId, userName}: Props) => {
 
   // helps to add a timesheet item to addedTimesheet state
   const onAddTimesheet = useCallback((data: Timesheet, reset?: Function) => {
-    const isDuplicateEntry = (section: CreateTimesheetDataprop) => {
+    const isDuplicateEntry = (section: ITimesheetSectionListItem) => {
       return section.data.some(item => item.timesheet_id === data.timesheet_id);
     };
 
-    const updateSections = (sections: CreateTimesheetDataprop[]) => {
+    const updateSections = (sections: ITimesheetSectionListItem[]) => {
       const foundSection = sections.find(
         section => section.title === data.project,
       );
@@ -107,7 +110,7 @@ const CreateTimesheet = ({toggleModal, isVisible, userId, userName}: Props) => {
   const onDelete = useCallback((timesheetData: Timesheet) => {
     setAddedTimesheet(sections => {
       const updatedSections = sections.reduce(
-        (prevVal: CreateTimesheetDataprop[], currVal) => {
+        (prevVal: ITimesheetSectionListItem[], currVal) => {
           const data = currVal.data.filter(
             item => item.timesheet_id !== timesheetData.timesheet_id,
           );
@@ -126,7 +129,7 @@ const CreateTimesheet = ({toggleModal, isVisible, userId, userName}: Props) => {
   const onEdit = (timesheetData: Timesheet) => {
     setAddedTimesheet(sections => {
       const updatedSections = sections.reduce(
-        (prevVal: CreateTimesheetDataprop[], currVal) => {
+        (prevVal: ITimesheetSectionListItem[], currVal) => {
           const data = currVal.data.filter(
             item => item.timesheet_id !== timesheetData.timesheet_id,
           );
@@ -174,6 +177,14 @@ const CreateTimesheet = ({toggleModal, isVisible, userId, userName}: Props) => {
     }
   }, [isSuccess, resetStates]);
 
+  useEffect(() => {
+    if (isPartiallyFailed && failedTimesheets) {
+      setAddedTimesheet(sections =>
+        convertFailedTimesheetsResponse(sections, failedTimesheets),
+      );
+    }
+  }, [isPartiallyFailed, failedTimesheets]);
+
   return (
     <Modal
       isVisible={isVisible}
@@ -200,6 +211,10 @@ const CreateTimesheet = ({toggleModal, isVisible, userId, userName}: Props) => {
       <Touchable type="opacity" onPress={toggleForm} style={styles.arrow}>
         <Arrow width={22} height={22} />
       </Touchable>
+
+      {isPartiallyFailed && (
+        <Typography type="error">{errorMessage}</Typography>
+      )}
 
       <View style={styles.list}>
         <SectionListTimesheet

--- a/src/app/screens/TimesheetScreen/view/createTimesheet.tsx
+++ b/src/app/screens/TimesheetScreen/view/createTimesheet.tsx
@@ -12,6 +12,7 @@ import {useAddTimesheet} from '../timesheet.hooks';
 
 import {convertToMins, dateFormate} from '../../../utils/date';
 import {convertFailedTimesheetsResponse} from '../../../utils/timesheet';
+import toast from '../../../utils/toast';
 
 import {ITimesheetSectionListItem, Timesheet} from '../interface';
 import colors from '../../../constant/colors';
@@ -43,7 +44,7 @@ const CreateTimesheet = ({toggleModal, isVisible, userId, userName}: Props) => {
     isLoading,
     isPartiallyFailed,
     failedTimesheets,
-    errorMessage,
+    message,
   } = useAddTimesheet();
 
   // mutation function
@@ -170,6 +171,12 @@ const CreateTimesheet = ({toggleModal, isVisible, userId, userName}: Props) => {
     toggleModal();
   }, [toggleModal]);
 
+  const onModalHide = () => {
+    if (isSuccess) {
+      toast(message!);
+    }
+  };
+
   // if add timesheet is succeed then reset all the states
   useEffect(() => {
     if (isSuccess) {
@@ -192,8 +199,9 @@ const CreateTimesheet = ({toggleModal, isVisible, userId, userName}: Props) => {
       animationOut={'slideOutDown'}
       animationInTiming={500}
       animationOutTiming={500}
-      onBackButtonPress={toggleModal}
-      onBackdropPress={toggleModal}
+      onBackButtonPress={resetStates}
+      onBackdropPress={resetStates}
+      onModalHide={onModalHide}
       contentStyle={styles.main}>
       <View style={styles.form}>
         <Typography type="title" style={styles.title}>
@@ -213,7 +221,9 @@ const CreateTimesheet = ({toggleModal, isVisible, userId, userName}: Props) => {
       </Touchable>
 
       {isPartiallyFailed && (
-        <Typography type="error">{errorMessage}</Typography>
+        <Typography type="error" style={styles.errorText}>
+          {message}
+        </Typography>
       )}
 
       <View style={styles.list}>
@@ -291,6 +301,9 @@ const styles = StyleSheet.create({
   list: {
     flex: 1,
     width: '100%',
+  },
+  errorText: {
+    paddingHorizontal: 16,
   },
 });
 

--- a/src/app/services/timesheet/types.ts
+++ b/src/app/services/timesheet/types.ts
@@ -46,13 +46,11 @@ export type TDeleteTimesheetRequest = {
 };
 
 export interface ITimesheetResponse {
-  code: number;
   message: string;
-  status: string;
 }
 
 export type TCerateTimsheetResponse = ITimesheetResponse & {
-  data: ITimesheetSectionList[];
+  data: {[key: string]: string[]};
 };
 
 export type TEmpListTSResponse = ITimesheetResponse & {

--- a/src/app/utils/timesheet/index.ts
+++ b/src/app/utils/timesheet/index.ts
@@ -1,0 +1,43 @@
+import {ISO_DATE_FROMAT} from '../../constant/date';
+import {
+  Timesheet,
+  ITimesheetSectionListItem,
+} from '../../screens/TimesheetScreen/interface';
+import {dateFormate} from '../date';
+
+/**
+ * Converts the failed timesheets response received from server into a specific format.
+ * @param timesheetSections The array of timesheet sections.
+ * @param failedTimesheets An object containing failed timesheets data.
+ * @returns The converted timesheets data in the desired format.
+ */
+export const convertFailedTimesheetsResponse = (
+  timesheetSections: ITimesheetSectionListItem[],
+  failedTimesheets: {
+    [key: string]: string[];
+  },
+) => {
+  const res = {} as {[key: string]: Timesheet[]};
+
+  timesheetSections.forEach(section => {
+    if (section.title in failedTimesheets) {
+      res[section.title] = [];
+      section.data.forEach(timesheet => {
+        if (
+          failedTimesheets[section.title].includes(
+            dateFormate(timesheet.date, ISO_DATE_FROMAT),
+          )
+        ) {
+          res[section.title].push(timesheet);
+        }
+      });
+    }
+  });
+
+  const output = Object.entries(res).map(([key, val]) => ({
+    title: key,
+    data: val,
+  }));
+
+  return output as ITimesheetSectionListItem[];
+};


### PR DESCRIPTION
### Ticket Links:
https://trello.com/c/nh0xTk5A/25-error-handling-on-create-timesheet

---

### Pull Request Description:
This PR resolves the bug of error handling in creating the timesheet modal. Previously, when the user create a timesheet which already filled with the same date & project, the error toast appears, and the modal will close. To overcome this issue we added error handling if the timesheet is already for the project and date, then they get an error at the top of timesheetList in the modal and able to edit only failed timesheets, and the saved timesheet gets disappeared from the screen.

---

### Pull Request Submission Checklist:

- [X] Self-reviewed the code prior to submitting the PR
- [X] Done thorough testing on local
- [X] Make sure no eslint and typescript issues.
- [X] Update Trello ticket and sub-tasks status

---


### Screenshots/Videos:
https://github.com/joshsoftware/intranet-mobile/assets/72058456/d2862ce1-31e7-49fe-a8e5-e59bee9f0c60




