### PR TITLE
input field tap style fixed

### DIFF
--- a/src/app/components/input/index.tsx
+++ b/src/app/components/input/index.tsx
@@ -8,7 +8,7 @@ import colors from '../../constant/colors';
 
 type Props = TextInputProps & {error?: string; StartIcon?: React.FC<SvgProps>};
 
-const Input = ({error, StartIcon, ...props}: Props) => {
+const Input = ({error, StartIcon, style, ...props}: Props) => {
   return (
     <>
       <View style={[styles.container, error ? styles.errorStyle : {}]}>
@@ -16,7 +16,7 @@ const Input = ({error, StartIcon, ...props}: Props) => {
           <StartIcon style={styles.startIcon} height={12} width={12} />
         )}
         <TextInput
-          style={StyleSheet.compose(styles.textInput, props.style)}
+          style={StyleSheet.compose(styles.textInput, style)}
           placeholderTextColor={colors.PLACEHOLDER_TEXT}
           {...props}
         />

--- a/src/app/screens/TimesheetScreen/component/timesheetForm.tsx
+++ b/src/app/screens/TimesheetScreen/component/timesheetForm.tsx
@@ -213,7 +213,6 @@ const styles = StyleSheet.create({
     marginVertical: 5,
   },
   description: {
-    alignItems: 'flex-start',
     maxHeight: 100,
     fontSize: 15,
   },


### PR DESCRIPTION
### Ticket Links:
https://trello.com/c/24AGhEc5/66-input-text-field-not-clickable

---

### Pull Request Description:
The input field tap covers the complete field area to tap.

---

### Pull Request Submission Checklist:
- Add an x in between the brackets to check off a relevant item, eg: [x]

- [X] Self-reviewed the code prior to submitting PR
- [X] Done a thorough testing on local
- [X] Make sure no eslint and typescript issues.
- [X] Update Trello ticket and sub-tasks status
